### PR TITLE
AutoShardedBot voice_client

### DIFF
--- a/discodo/client/DPYClient.py
+++ b/discodo/client/DPYClient.py
@@ -75,7 +75,7 @@ class DPYClient:
             if originFunc:
                 return await originFunc()
 
-        if isinstance(self.client, commands.Bot):
+        if isinstance(self.client, (commands.Bot, commands.AutoShardedBot)):
             originContextFunc = commands.Context.voice_client.fget
 
             @commands.Context.voice_client.getter


### PR DESCRIPTION
Fixed returning `None` when getting `ctx.voice_client` when using `AutoShardedBot`.